### PR TITLE
update react-scripts to publish to joor github packages

### DIFF
--- a/packages/react-scripts/.npmrc
+++ b/packages/react-scripts/.npmrc
@@ -1,0 +1,2 @@
+registry=https://npm.pkg.github.com/joor
+//npm.pkg.github.com/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
This PR adds an `.npmrc` file to point to joor's github packages repository. It is necessary because consuming projects can only designate a single registry for consuming projects of the same scope `@joor`.